### PR TITLE
[rbgen 1/2]: preparation (don't squash)

### DIFF
--- a/chunk-charted-handler.lua
+++ b/chunk-charted-handler.lua
@@ -7,7 +7,6 @@ end
 
 
 
-local total_number_of_tiles_in_a_chunk = 32 * 32;
 
 local function on_chunk_charted(event)
     if math.abs(event.position.x) < 5 and math.abs(event.position.y) < 5 then
@@ -23,7 +22,7 @@ local function on_chunk_charted(event)
                 name = { "water", "deepwater" }
             }
 
-            local water_ratio = (water_tile_count / total_number_of_tiles_in_a_chunk)
+            local water_ratio = (water_tile_count / Constants.CHUNK_SIZE^2)
             local has_enough_water = water_ratio > 0.25 and water_ratio < 0.9
             if not has_enough_water then
                 return

--- a/chunk-charted-handler.lua
+++ b/chunk-charted-handler.lua
@@ -47,6 +47,15 @@ local function on_chunk_charted(event)
         return
     end
 
+    -- place pending tags
+    if global.tycoon_tags_queue ~= nil then
+        local k = Util.chunkToHash(event.position)
+        local pos_name = global.tycoon_tags_queue[k]
+        if pos_name ~= nil then
+            PrimaryIndustries.tagIndustry(table.unpack(pos_name))
+        end
+    end
+
     if global.tycoon_global_generator() < 0.25 then
         local entity_name = randomPrimaryIndustry()
         local position
@@ -97,6 +106,20 @@ local function on_chunk_deleted(event)
     end
 
     PrimaryIndustries.cleanup_global_primary_industries()
+
+    local count = 0
+    for i, chunk in pairs(event.positions) do
+        -- remove pending tags
+        if global.tycoon_tags_queue ~= nil then
+            local k = Util.chunkToHash(chunk)
+            local t = global.tycoon_tags_queue[k]
+            if t ~= nil then
+                global.tycoon_tags_queue[k] = nil
+                count = count + 1
+            end
+        end
+    end
+    log("tycoon_tags_queue removed: ".. tostring(count))
 end
 
 

--- a/chunk-charted-handler.lua
+++ b/chunk-charted-handler.lua
@@ -95,6 +95,8 @@ local function on_chunk_deleted(event)
     if event.surface_index ~= Constants.STARTING_SURFACE_ID then
         return
     end
+
+    PrimaryIndustries.cleanup_global_primary_industries()
 end
 
 

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -447,7 +447,7 @@ local function tag_cities()
         if city.tag == nil and (city.special_buildings.town_hall or {}).valid then
             local tag = game.forces.player.add_chart_tag(game.surfaces[Constants.STARTING_SURFACE_ID],
                 {
-                    position = { x = city.special_buildings.town_hall.position.x, y = city.special_buildings.town_hall.position.y },
+                    position = city.center,
                     text = city.name
                 }
             )

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -448,7 +448,7 @@ local function tag_cities()
     for _, city in ipairs(global.tycoon_cities or {}) do
         -- We need to initialize the tag here, because tags can only be placed on charted chunks.
         -- And the game needs a moment to start and chart the initial chunks, even if it can already place entities.
-        if city.tag == nil and (city.special_buildings.town_hall or {}).valid then
+        if city.tag == nil or not (city.tag or {}).valid then
             local tag = game.forces.player.add_chart_tag(game.surfaces[Constants.STARTING_SURFACE_ID],
                 {
                     position = city.center,
@@ -458,7 +458,7 @@ local function tag_cities()
             city.tag = tag
         end
         -- append population
-        if city.tag ~= nil then
+        if (city.tag or {}).valid then
             if (settings.global["tycoon-tags-show-population"] or {}).value then
                 local count = 0
                 for _, n in pairs(city.citizens) do

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -249,6 +249,9 @@ local function initializeCity(city)
             end
         end
     end
+    -- BUG: town hall is always +1.5 cells to the right-bottom and graphics are off-by-one
+    -- can't set city.center to actual position of town hall, so lets just make it integer
+    city.center = { x = math.floor(city.center.x), y = math.floor(city.center.y) }
 
     local possibleRoadEnds = {
         {
@@ -342,6 +345,7 @@ local function addCity(position, predefinedCityName)
             town_hall = nil,
             other = {}
         },
+        -- WARN: don't floor it here yet - initializeCity() will make displaced grid
         center = position,
         name = cityName,
         stats = {
@@ -359,7 +363,7 @@ local function addCity(position, predefinedCityName)
 
     game.print({ "",
         "[color=orange]Factorio Tycoon:[/color] ", { "tycooon-new-city", cityName }, ": ",
-        "[gps=" .. (position.x + 1.5 * Constants.CELL_SIZE) .. "," .. (position.y + 1.5 * Constants.CELL_SIZE) .. "]",
+        "[gps=" .. (math.floor(position.x) + 1.5 * Constants.CELL_SIZE) .. "," .. (math.floor(position.y) + 1.5 * Constants.CELL_SIZE) .. "]",
     })
     return cityName
 end

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -357,6 +357,10 @@ local function addCity(position, predefinedCityName)
     initializeCity(global.tycoon_cities[cityId])
     Consumption.updateNeeds(global.tycoon_cities[cityId])
 
+    game.print({ "",
+        "[color=orange]Factorio Tycoon:[/color] ", { "tycooon-new-city", cityName }, ": ",
+        "[gps=" .. (position.x + 1.5 * Constants.CELL_SIZE) .. "," .. (position.y + 1.5 * Constants.CELL_SIZE) .. "]",
+    })
     return cityName
 end
 
@@ -406,8 +410,11 @@ local function addMoreCities(isInitialCity, skipPayment)
     local newCityPosition = findNewCityPosition(isInitialCity)
     if newCityPosition ~= nil then
         local cityName = addCity(newCityPosition)
+        -- disabled for now, moved into addCity() above
+        if false then
         game.print({ "", "[color=orange]Factorio Tycoon:[/color] ", { "tycooon-new-city", cityName }, ": ", "[gps=" ..
         (newCityPosition.x + 1.5 * Constants.CELL_SIZE) .. "," .. (newCityPosition.y + 1.5 * Constants.CELL_SIZE) .. "]" })
+        end
 
         if not skipPayment then
             local urbanPlanningCenters = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered {

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -43,10 +43,7 @@ local function find_random_city_position()
     local chunk = game.surfaces[Constants.STARTING_SURFACE_ID].get_random_chunk()
     if chunk ~= nil then
         if game.forces.player.is_chunk_charted(game.surfaces[Constants.STARTING_SURFACE_ID], chunk) then
-            return {
-                x = chunk.x * 32,
-                y = chunk.y * 32,
-            }
+            return Util.chunkToPosition(chunk)
         end
     end
     return nil

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -440,7 +440,7 @@ local function tag_cities()
     for _, city in ipairs(global.tycoon_cities or {}) do
         -- We need to initialize the tag here, because tags can only be placed on charted chunks.
         -- And the game needs a moment to start and chart the initial chunks, even if it can already place entities.
-        if city.tag == nil and city.special_buildings.town_hall ~= nil then
+        if city.tag == nil and (city.special_buildings.town_hall or {}).valid then
             local tag = game.forces.player.add_chart_tag(game.surfaces[Constants.STARTING_SURFACE_ID],
                 {
                     position = { x = city.special_buildings.town_hall.position.x, y = city.special_buildings.town_hall.position.y },

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -453,6 +453,19 @@ local function tag_cities()
             )
             city.tag = tag
         end
+        -- append population
+        if city.tag ~= nil then
+            if (settings.global["tycoon-tags-show-population"] or {}).value then
+                local count = 0
+                for _, n in pairs(city.citizens) do
+                    count = count + n
+                end
+                city.tag.text = city.name .." [color=gray][".. tostring(count) .."][/color]"
+            else
+                -- won't lag (called every ~30s), otherwise tail is left
+                city.tag.text = city.name
+            end
+        end
     end
 end
 

--- a/city.lua
+++ b/city.lua
@@ -897,8 +897,8 @@ end
 --- @param coordinates Coordinates
 local function isCharted(city, coordinates)
     local chunkPosition = {
-        y = math.floor((GridUtil.getOffsetY(city) + coordinates.y * Constants.CELL_SIZE) / 32),
-        x = math.floor((GridUtil.getOffsetX(city) + coordinates.x * Constants.CELL_SIZE) / 32),
+        y = math.floor((GridUtil.getOffsetY(city) + coordinates.y * Constants.CELL_SIZE) / Constants.CHUNK_SIZE),
+        x = math.floor((GridUtil.getOffsetX(city) + coordinates.x * Constants.CELL_SIZE) / Constants.CHUNK_SIZE),
     }
     return game.forces.player.is_chunk_charted(game.surfaces[Constants.STARTING_SURFACE_ID], chunkPosition)
 end

--- a/city.lua
+++ b/city.lua
@@ -776,10 +776,10 @@ local function list_special_city_buildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    elseif (city.special_buildings.town_hall or {}).valid then
+    else
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
-            position=city.special_buildings.town_hall.position,
+            position=city.center,
             radius=Constants.CITY_RADIUS,
         }
         city.special_buildings.other[name] = entities

--- a/city.lua
+++ b/city.lua
@@ -776,7 +776,7 @@ local function list_special_city_buildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    else
+    elseif (city.special_buildings.town_hall or {}).valid then
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
             position=city.special_buildings.town_hall.position,

--- a/constants.lua
+++ b/constants.lua
@@ -4,6 +4,11 @@ local CHUNK_SIZE = 32  -- Lua is insane, no access from the same table
 
 local CONSTANTS = {
     CHUNK_SIZE = CHUNK_SIZE,
+    -- nothing would be generated inside this area, except for initial farms if enabled
+    STARTING_RADIUS_CHUNKS = 128 / CHUNK_SIZE,
+    -- NOTE: map_gen_settings.starting_area is mapped as [100%; 600%] => [1; multiplier]
+    -- ex: 4(see above) * 4(here) makes SA 600% as 1024x1024 tiles total, 1 disables that setting effect
+    STARTING_AREA_MULTIPLIER = 4,
 
     -- Each cell has 6x6 tiles
     CELL_SIZE = 6,

--- a/constants.lua
+++ b/constants.lua
@@ -1,6 +1,10 @@
 local OneSecond = 60
+-- Factorio's chunk size, in tiles
+local CHUNK_SIZE = 32  -- Lua is insane, no access from the same table
 
 local CONSTANTS = {
+    CHUNK_SIZE = CHUNK_SIZE,
+
     -- Each cell has 6x6 tiles
     CELL_SIZE = 6,
     CITY_GROWTH_TICKS = OneSecond * 60,

--- a/consumption.lua
+++ b/consumption.lua
@@ -232,10 +232,10 @@ local function listSpecialCityBuildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    elseif (city.special_buildings.town_hall or {}).valid then
+    else
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
-            position=city.special_buildings.town_hall.position,
+            position=city.center,
             radius=Constants.CITY_RADIUS
         }
         city.special_buildings.other[name] = entities

--- a/consumption.lua
+++ b/consumption.lua
@@ -232,7 +232,7 @@ local function listSpecialCityBuildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    else
+    elseif (city.special_buildings.town_hall or {}).valid then
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
             position=city.special_buildings.town_hall.position,

--- a/control.lua
+++ b/control.lua
@@ -105,8 +105,16 @@ script.on_event({
     OnConstructionHandler.on_removed(event)
 end)
 
+script.on_event(defines.events.on_chunk_generated, function (event)
+    OnChunkChartedHandler.on_chunk_generated(event)
+end)
+
 script.on_event(defines.events.on_chunk_charted, function (event)
     OnChunkChartedHandler.on_chunk_charted(event)
+end)
+
+script.on_event(defines.events.on_chunk_deleted, function (event)
+    OnChunkChartedHandler.on_chunk_deleted(event)
 end)
 
 script.on_event(defines.events.on_player_cursor_stack_changed, function(event)

--- a/gui.lua
+++ b/gui.lua
@@ -347,7 +347,7 @@ local function listSpecialCityBuildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    else
+    elseif (city.special_buildings.town_hall or {}).valid then
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
             position=city.special_buildings.town_hall.position,

--- a/gui.lua
+++ b/gui.lua
@@ -347,10 +347,10 @@ local function listSpecialCityBuildings(city, name)
     local entities = {}
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
-    elseif (city.special_buildings.town_hall or {}).valid then
+    else
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
-            position=city.special_buildings.town_hall.position,
+            position=city.center,
             radius=Constants.CITY_RADIUS
         }
         city.special_buildings.other[name] = entities

--- a/locale/en/mod-setting-description.cfg
+++ b/locale/en/mod-setting-description.cfg
@@ -1,3 +1,4 @@
 [mod-setting-description]
 tycoon-spawn-initial-city=Warning: This setting is only for you if you know how to work with remote interfaces, so that you can actually spawn a city. Don't disable this if you just want to play the Tycoon mod.
 tycoon-tags-text-length=Limits maximum text length for map tags (mostly for Primary industries)\nexamples: 5, 1 or 0 for no text at all (only icons)
+tycoon-skip-check-resources=Skip check for nearby resources when placing industries.\nEnable if you experience performance issues when exploring (ex: resource-adding mods) and don't mind placing on them.

--- a/locale/en/mod-setting-description.cfg
+++ b/locale/en/mod-setting-description.cfg
@@ -1,4 +1,5 @@
 [mod-setting-description]
 tycoon-spawn-initial-city=Warning: This setting is only for you if you know how to work with remote interfaces, so that you can actually spawn a city. Don't disable this if you just want to play the Tycoon mod.
 tycoon-tags-text-length=Limits maximum text length for map tags (mostly for Primary industries)\nexamples: 5, 1 or 0 for no text at all (only icons)
+tycoon-tags-show-population=Shows current population next to city names.\nUpdates about every minute or so.
 tycoon-skip-check-resources=Skip check for nearby resources when placing industries.\nEnable if you experience performance issues when exploring (ex: resource-adding mods) and don't mind placing on them.

--- a/locale/en/mod-setting-name.cfg
+++ b/locale/en/mod-setting-name.cfg
@@ -1,4 +1,5 @@
 [mod-setting-name]
 tycoon-spawn-initial-city=Spawn the initial city
 tycoon-tags-text-length=Tags text length
+tycoon-tags-show-population=Show population
 tycoon-skip-check-resources=Skip generation check: resources

--- a/locale/en/mod-setting-name.cfg
+++ b/locale/en/mod-setting-name.cfg
@@ -1,3 +1,4 @@
 [mod-setting-name]
 tycoon-spawn-initial-city=Spawn the initial city
 tycoon-tags-text-length=Tags text length
+tycoon-skip-check-resources=Skip generation check: resources

--- a/migrations/0.4.5-fix-city-centers.lua
+++ b/migrations/0.4.5-fix-city-centers.lua
@@ -1,0 +1,15 @@
+-- WARN: migrations are run BEFORE any init(), always need this here
+if global.tycoon_cities == nil then
+    global.tycoon_cities = {}
+end
+
+for _, city in pairs(global.tycoon_cities) do
+    local _, x = math.modf(city.center.x)
+    local _, y = math.modf(city.center.y)
+    if math.abs(x) > 0.001 or math.abs(y) > 0.001 then
+        log(string.format("non-integer center: %.3f, %.3f id: %d name: %s",
+            city.center.x, city.center.y, city.id, city.name
+        ))
+        city.center = { x = math.floor(city.center.x), y = math.floor(city.center.y) }
+    end
+end

--- a/passengers.lua
+++ b/passengers.lua
@@ -22,12 +22,9 @@ local function listSpecialCityBuildings(city, name)
     if city.special_buildings.other[name] ~= nil and #city.special_buildings.other[name] > 0 then
         entities = city.special_buildings.other[name]
     else
-        if not city.special_buildings.town_hall.valid then
-            return {}
-        end
         entities = game.surfaces[Constants.STARTING_SURFACE_ID].find_entities_filtered{
             name=name,
-            position=city.special_buildings.town_hall.position,
+            position=city.center,
             radius=Constants.CITY_RADIUS
         }
         city.special_buildings.other[name] = entities

--- a/primary-industries.lua
+++ b/primary-industries.lua
@@ -15,6 +15,24 @@ local function add_to_global_primary_industries(entity)
     table.insert(global.tycoon_primary_industries[entity.name], entity)
 end
 
+local function cleanup_global_primary_industries()
+    -- TODO: when called from on_chunk_deleted() - it doesn't clean fully, adding some delay might help (but how?)...
+    -- unless we have some array issue here, again. deleting 1K map keep-radius=2 count: 15 14 4 => 7 7 2 (?)
+    local count = 0
+    for name, _ in pairs(global.tycoon_primary_industries or {}) do
+        for k, entity in pairs(global.tycoon_primary_industries[name] or {}) do
+            if not entity.valid then
+                table.remove(global.tycoon_primary_industries[name], k)
+                count = count + 1
+            end
+        end
+    end
+    if count ~= 0 then
+        log("tycoon_primary_industries removed: ".. tostring(count))
+    end
+end
+
+
 local function getItemForPrimaryProduction(name)
     if name == "tycoon-apple-farm" then
         return "tycoon-apple"
@@ -193,6 +211,7 @@ end
 return {
     place_primary_industry_at_position = place_primary_industry_at_position,
     add_to_global_primary_industries = add_to_global_primary_industries,
+    cleanup_global_primary_industries = cleanup_global_primary_industries,
     spawn_initial_industry = spawn_initial_industry,
     getFixedRecipeForIndustry = getFixedRecipeForIndustry,
 }

--- a/prototypes/entities/apple-farm.lua
+++ b/prototypes/entities/apple-farm.lua
@@ -18,14 +18,14 @@ data:extend{
                 height = 2,
                 base_level = -1,
                 pipe_connections = {
-                    { type = "input", position = { 7.3, 0.4 } },
+                    { type = "input", position = { 7.3, 0.0 } },
                 },
             },
             off_when_no_fluid_recipe = false,
         },
-        collision_box = { { -6.9, -5.4}, {6.9, 6.9} },
+        collision_box = { { -6.9, -5.4}, {6.9, 7.4} },
         collision_mask = { "player-layer", "water-tile", "resource-layer", "item-layer", "ghost-layer", "object-layer", "train-layer", "rail-layer", "transport-belt-layer" },
-        selection_box = { { -6.9, -5.4}, {6.9, 6.9} },
+        selection_box = { { -6.9, -5.4}, {6.9, 7.4} },
         window_bounding_box = { { -0.125, 0.6875 }, { 0.1875, 1.1875 } },
         animation = {
             layers = {
@@ -34,7 +34,7 @@ data:extend{
                     priority = "high",
                     width = 500,
                     height = 500,
-                    shift = {0, 0},
+                    shift = {0, 0.5},
                     scale = 1
                 }
             },

--- a/settings.lua
+++ b/settings.lua
@@ -15,6 +15,13 @@ data:extend({
     },
     {
         type = "bool-setting",
+        name = "tycoon-tags-show-population",
+        order = "4-t-s",
+        setting_type = "runtime-global",
+        default_value = true,
+    },
+    {
+        type = "bool-setting",
         name = "tycoon-skip-check-resources",
         order = "5-s-c",
         setting_type = "runtime-global",

--- a/settings.lua
+++ b/settings.lua
@@ -13,4 +13,11 @@ data:extend({
         minimum_value = 0,
         maximum_value = 32,
     },
+    {
+        type = "bool-setting",
+        name = "tycoon-skip-check-resources",
+        order = "5-s-c",
+        setting_type = "runtime-global",
+        default_value = false,
+    },
 })

--- a/util-bitwise.lua
+++ b/util-bitwise.lua
@@ -1,0 +1,65 @@
+-- could require("__stdlib__/utils/math"), though it has few off-by-one errors (as of 2024-03-02)
+
+--local MIN_S32 = -2147483648
+--local MAX_S32 =  2147483647
+--local MIN_S16 = -32768
+--local MAX_S16 =  32767
+local MAX_U16 =  65535
+local MASK15 = 0x00007fff
+local MASK16 = 0x0000ffff
+local MASK32 = 0xffffffff
+local MSIG16 = MASK15 + 1
+--local MSIG32 = 0x80000000
+
+--
+-- Factorio-Lua, OHNOES - bitwise operators, please!
+--
+local _and = bit32.band
+local _or  = bit32.bor
+local _ls  = bit32.lshift
+local _rs  = bit32.rshift
+
+
+-- module
+local M = {}
+
+--- this is similar to packing 2xInt8 like this:
+--- FEDCBA9876543210 bit position
+--- SxxxxxxxBbbbbbbb 16-bit signed
+--- SbbbbbbbSbbbbbbb  8-bit signed x2
+function M.pack2xInt16(x, y)
+    --return ( ((y & MASK16) << 16) | (x & MASK16) ) & MASK32
+    return _and(_or(
+        _ls(_and(y, MASK16), 16),
+            _and(x, MASK16)
+    ), MASK32)
+end
+
+function M.unpack2xInt16(k)
+    local x = _and(k, MASK16)  -- k & MASK16
+    local y = _rs(k, 16)       -- k >> 16
+
+    --log(string.format("k: 0x%08x xy: {0x%04x 0x%04x} xy_u16: {%d %d}", k, x, y, x, y))
+    x = x + ((_and(x, MSIG16) ~= 0) and -(MAX_U16 + 1) or 0)  -- (x & MSIG16) ~= 0
+    y = y + ((_and(y, MSIG16) ~= 0) and -(MAX_U16 + 1) or 0)  -- (y & MSIG16) ~= 0
+    return { x, y }
+end
+
+--
+-- tests
+--
+assert(M.pack2xInt16(    -2,     -3) == 0xfffdfffe)
+assert(M.pack2xInt16( 65534,  65533) == 0xfffdfffe)
+assert(M.pack2xInt16(-16657,  -8531) == 0xDeadBeef)
+assert(M.pack2xInt16( 48879,  57005) == 0xDeadBeef)
+assert(M.pack2xInt16( 32767,  32766) == 0x7ffe7fff)
+assert(M.pack2xInt16(-98305, -98306) == 0x7ffe7fff)
+assert(M.pack2xInt16(-32767, -32766) == 0x80028001)
+local xy = {}  -- luacheck: ignore
+xy = M.unpack2xInt16(0xfffdfffe); assert(xy[1] ==     -2 and xy[2] ==     -3)
+xy = M.unpack2xInt16(0xDeadBeef); assert(xy[1] == -16657 and xy[2] ==  -8531)
+xy = M.unpack2xInt16(0x7ffe7fff); assert(xy[1] ==  32767 and xy[2] ==  32766)
+xy = M.unpack2xInt16(0x80028001); assert(xy[1] == -32767 and xy[2] == -32766)
+
+
+return M

--- a/util.lua
+++ b/util.lua
@@ -73,10 +73,31 @@ local function positionToChunk(p)
     return { x = math.floor(p.x / Constants.CHUNK_SIZE), y = math.floor(p.y / Constants.CHUNK_SIZE) }
 end
 
+--- @param p Position
+--- @param size number Region size
+--- @return RegionPosition
+local function positionToRegion(p, size)
+    return { x = math.floor(p.x / (Constants.CHUNK_SIZE * size)), y = math.floor(p.y / (Constants.CHUNK_SIZE * size)) }
+end
+
 --- @param ch ChunkPosition
 --- @return Position
 local function chunkToPosition(ch)
     return { x = ch.x * Constants.CHUNK_SIZE, y = ch.y * Constants.CHUNK_SIZE }
+end
+
+--- @param ch ChunkPosition
+--- @param size number Region size
+--- @return Position
+local function chunkToRegion(ch, size)
+    return { x = math.floor(ch.x / size), y = math.floor(ch.y / size) }
+end
+
+--- @param ch ChunkPosition
+--- @param size number Size of array in one dimension
+--- @return number Index in array
+local function chunkToIndex2D(ch, size)
+    return math.floor(ch.y % size)*size + math.floor(ch.x % size)
 end
 
 --- we could use string.format("%d;%d", p.x, p.y), but it looks slower
@@ -202,7 +223,10 @@ return {
     lerpClamped = lerpClamped,
 
     positionToChunk = positionToChunk,
+    positionToRegion = positionToRegion,
     chunkToPosition = chunkToPosition,
+    chunkToRegion = chunkToRegion,
+    chunkToIndex2D = chunkToIndex2D,
     chunkToHash = chunkToHash,
     chunkFromHash = chunkFromHash,
 

--- a/util.lua
+++ b/util.lua
@@ -72,7 +72,8 @@ end
 
 local function findCityByTownHallUnitNumber(townHallUnitNumber)
     for _, city in ipairs(global.tycoon_cities) do
-        if (city.special_buildings.town_hall or {}).unit_number == townHallUnitNumber then
+        if (city.special_buildings.town_hall or {}).valid
+            and (city.special_buildings.town_hall or {}).unit_number == townHallUnitNumber then
             return city
         end
     end

--- a/util.lua
+++ b/util.lua
@@ -1,4 +1,5 @@
 local Constants = require("constants")
+local UtilBitwise = require("util-bitwise")
 
 local function splitString(s, delimiter)
     local parts = {}
@@ -29,6 +30,88 @@ local function calculateDistance(p1, p2)
     local dy = p2.y - p1.y
     return math.sqrt(dx * dx + dy * dy)
 end
+
+--- @param v number
+--- @param min number
+--- @param max number
+--- @return number Clamped value to [min;max] range
+local function clamp(v, min, max)
+    if v < min then
+        return min
+    elseif v > max then
+        return max
+    end
+    return v
+end
+
+--- @param v number
+--- @param min number Lower bound of v
+--- @param max number Upper bound of v
+--- @return number Normalized value in [0;1] range
+local function normalize(v, min, max)
+    return (v - min) / (max - min)
+end
+
+--- @param v number Normalized value in [0;1] range
+--- @param min number
+--- @param max number
+--- @return number Linear interpolation of [min;max] range by v
+local function lerp(v, min, max)
+    return min + (max - min)*v
+end
+
+--- Similar to lerp, but clamps v into [0;1] range
+local function lerpClamped(v, min, max)
+    return lerp(clamp(v, 0, 1), min, max)
+end
+
+--- @param p Position
+--- @return ChunkPosition
+local function positionToChunk(p)
+    -- Factorio-Lua, // // // !
+    --return { x = p.x // Constants.CHUNK_SIZE, y = p.y // Constants.CHUNK_SIZE }
+    return { x = math.floor(p.x / Constants.CHUNK_SIZE), y = math.floor(p.y / Constants.CHUNK_SIZE) }
+end
+
+--- @param ch ChunkPosition
+--- @return Position
+local function chunkToPosition(ch)
+    return { x = ch.x * Constants.CHUNK_SIZE, y = ch.y * Constants.CHUNK_SIZE }
+end
+
+--- we could use string.format("%d;%d", p.x, p.y), but it looks slower
+--- @param p ChunkPosition, only integers please! For floats use math.floor()
+--- @return number Hash to be used for dictionary keys
+local function chunkToHash(p)
+    -- WARN: only 16-bit signed values [-32768; 32767] are usable, uncomment assert to crash with message
+    --assert( (p.x >= -32768 and p.x <= 32767) and (p.y >= -32768 and p.y <= 32767) )
+    return UtilBitwise.pack2xInt16(p.x, p.y)
+end
+
+--- @param k Hash used for dictionary keys, as returned by chunkToHash()
+--- @return ChunkPosition
+local function chunkFromHash(k)
+    local p = UtilBitwise.unpack2xInt16(k)
+    return { x = p[1], y = p[2] }
+end
+
+--- @param v number Factorio slider value [0.16; 6.0] aka [17%; 600%] as in gui
+--- @return number value in the [-1; 1] range
+local function factorioSliderInverse(v)
+    -- formula is like e^((x-1)/3) for x==[-5;6], but can't find it. starting value 0 or 1?
+    --  x:   -5   -4   -3   -2   -1    0    1    2    3    4    5    6
+    --  v: 0.16 0.25 0.33 0.50 0.75 1.00 1.33 1.50 2.00 3.00 4.00 6.00
+    if v < 1.0 then
+        return (1 - 1/v)/(6-1)
+    end
+
+    return normalize(v, 1, 6)
+end
+
+assert(factorioSliderInverse(1/6) == -1)
+assert(factorioSliderInverse(1.0) ==  0)
+assert(factorioSliderInverse(6.0) ==  1)
+
 
 --- @param lowerTierBuildingCounts number
 --- @param higherTierBuildingCounts number
@@ -112,6 +195,19 @@ return {
     splitString = splitString,
     indexOf = indexOf,
     calculateDistance = calculateDistance,
+
+    clamp = clamp,
+    normalize = normalize,
+    lerp = lerp,
+    lerpClamped = lerpClamped,
+
+    positionToChunk = positionToChunk,
+    chunkToPosition = chunkToPosition,
+    chunkToHash = chunkToHash,
+    chunkFromHash = chunkFromHash,
+
+    factorioSliderInverse = factorioSliderInverse,
+
     findCityByTownHallUnitNumber = findCityByTownHallUnitNumber,
     findCityById = findCityById,
     isSupplyBuilding = isSupplyBuilding,


### PR DESCRIPTION
okay, this i'd like to be reviewed, tested and merged into main branch. then i can continue on `rbgen`, because it needs almost all of this...

**release is not necessary** unless you want to provide rare crash fixes to current players (or who deletes chunks)
this ~~is~~ **was** mostly dev/chore PR with only ~~1 feature~~ 2 features:
- `map_gen_settings.starting_area` being supported for those who reserves 0,0 for bases, but it doesn't move `Spawn Initial City` thing yet
- while deferred tag placement is of no use right now, it shouldn't do anything wrong.
- **NEW:** check for nearby resources on industry placement and `Skip generation check: resources` option
- **NEW:** city population is shown in their names with `Show population` option

_p.s. don't know how you want your repository to look, but i would like these commits not to be squashed if possible, so we can look through history and revert/disable stuff for any reason. i didn't put that amount of information inside commit messages this time, but tried to keep them minimal and isolated as much as possible.
p.p.s. my previous (#265) commits had useful information, but squash-merge removed it completely. :( so i had to create [pr-1](/winex/factorio-tycoon/tree/pr-1) branch to keep that history_

hope this complies with your standards! :) and, of course, i always rebase my branches against latest commit, so things look nice and clean!

_**edits:** rebased, added 2nd feature_