### PR TITLE
fix: make crowdin script darwin compatible

### DIFF
--- a/scripts/compare_locales.sh
+++ b/scripts/compare_locales.sh
@@ -54,7 +54,7 @@ for source_file in "$base_dir/$base_lang"/*.cfg; do
     # Iterate over target languages
     for lang in "${target_langs[@]}"; do
         # Define the file path for the target language
-        target_file="$base_dir/$lang/$filename"
+        target_file="$lang/$filename"
 
         # Check if the target file exists
         [[ ! -f $target_file ]] && {

--- a/scripts/compare_locales.sh
+++ b/scripts/compare_locales.sh
@@ -18,10 +18,23 @@ base_lang="en"
 # Initialize an empty array for target languages
 target_langs=()
 
+# MacOS compatibility:
+#   'stat -f "%N"' instead
+#   'sort -z' not supported, can't pipe 'find -print0'
+# WARN: as var is double-quoted below, there should be no whitespaces!
+STAT_OPTS="-c%n"
+case "$(uname -s)" in
+    Darwin*)
+        STAT_OPTS="-f%N"
+        ;;
+    Linux*|*)
+        ;;
+esac
+
 # Populate the array with directory names excluding the base language
 while IFS= read -r line; do
     target_langs+=("$line")
-done < <(find "$base_dir" -mindepth 1 -maxdepth 1 -type d -not -name "$base_lang" -printf "%P\n" | LC_ALL=C sort)
+done < <(find "$base_dir" -mindepth 1 -maxdepth 1 -type d -not -name "$base_lang" -print0 | xargs -0 stat "$STAT_OPTS" | LC_ALL=C sort)
 
 # Iterate over all files in the base language directory
 tmp_file=
@@ -30,7 +43,7 @@ for source_file in "$base_dir/$base_lang"/*.cfg; do
     filename=$(basename "$source_file")
 
     # Create temp file only once and reuse
-    [[ -z $tmp_file ]] && tmp_file=$(mktemp --tmpdir "compare-locales.XXXXXXXX")
+    [[ -z $tmp_file ]] && tmp_file=$(mktemp -t "compare-locales.XXXXXXXX")
     # Overwrite temp file with extracted keys
     extract_keys "$source_file" >"$tmp_file" || {
         let ERRORS+=1000


### PR DESCRIPTION
When I run this on darwin, it looks like the locale part is duplicated:

```
ERROR: File does not exist: locale/locale/de/controls.cfg
ERROR: File does not exist: locale/locale/ja/controls.cfg
ERROR: File does not exist: locale/locale/pt-BR/controls.cfg
...
```

---

Note that I changed `--tempdir` to `-t` because the former is not supported on darwin, and I think `-t` is the equivalent maybe?

Without that changed here's what I see:

```
...
./scripts/compare_locales.sh: line 48: : No such file or directory
ERROR: Unable to extract from: locale/en/tips-and-tricks-item-description.cfg
mktemp: illegal option -- -
usage: mktemp [-d] [-q] [-t prefix] [-u] template ...
       mktemp [-d] [-q] [-u] -t prefix 
...
```