### PR TITLE
fix: handle destroyed buildings properly

### DIFF
--- a/city-planner.lua
+++ b/city-planner.lua
@@ -231,6 +231,8 @@ local function initializeCity(city)
                     }
                     townHall.destructible = false
                     city.special_buildings.town_hall = townHall
+                    --- NOTE: townHall is also a building in our grid, assign proper entity
+                    cell.entity = townHall
                     Util.addGlobalBuilding(townHall.unit_number, city.id, townHall)
                     -- The town hall should start with some nicer flooring
                     Util.printTiles(startCoordinates, map, Constants.GROUND_TILE_TYPES.residential, city.surface_index)

--- a/city-planner.lua
+++ b/city-planner.lua
@@ -231,11 +231,7 @@ local function initializeCity(city)
                     }
                     townHall.destructible = false
                     city.special_buildings.town_hall = townHall
-                    global.tycoon_city_buildings[townHall.unit_number] = {
-                        cityId = city.id,
-                        entity_name = townHall.name,
-                        entity = townHall
-                    }
+                    Util.addGlobalBuilding(townHall.unit_number, city.id, townHall)
                     -- The town hall should start with some nicer flooring
                     Util.printTiles(startCoordinates, map, Constants.GROUND_TILE_TYPES.residential, city.surface_index)
                 end

--- a/city.lua
+++ b/city.lua
@@ -1308,6 +1308,8 @@ local function completeConstruction(city, buildingTypes)
         entity = entity,
     }
     Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+    -- WARN: we must always register
+    script.register_on_entity_destroyed(entity)
 
     if housingTier == "tycoon-treasury" and not global.tycoon_intro_message_treasury_displayed then
         game.print({"", "[color=orange]Factorio Tycoon:[/color] ", {"tycooon-info-message-treasury"}})

--- a/city.lua
+++ b/city.lua
@@ -1290,11 +1290,7 @@ local function completeConstruction(city, buildingTypes)
         createdAtTick = game.tick,
         entity = entity,
     }
-    global.tycoon_city_buildings[entity.unit_number] = {
-        cityId = city.id,
-        entity_name = entity.name,
-        entity = entity,
-    }
+    Util.addGlobalBuilding(entity.unit_number, city.id, entity)
 
     if housingTier == "tycoon-treasury" and not global.tycoon_intro_message_treasury_displayed then
         game.print({"", "[color=orange]Factorio Tycoon:[/color] ", {"tycooon-info-message-treasury"}})

--- a/construction-event-handler.lua
+++ b/construction-event-handler.lua
@@ -39,6 +39,8 @@ local function on_built(event)
         }
 
         Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+        -- WARN: we must always register
+        script.register_on_entity_destroyed(entity)
     end
 end
 

--- a/construction-event-handler.lua
+++ b/construction-event-handler.lua
@@ -31,6 +31,7 @@ local function on_built(event)
 
         invalidateSpecialBuildingsList(city, entity.name)
 
+        -- TODO: this could be dropped in favor of Util.getGlobalBuilding()
         if global.tycoon_entity_meta_info == nil then
             global.tycoon_entity_meta_info = {}
         end
@@ -78,6 +79,12 @@ local function on_removed(event)
 
     if building.isSpecial or Util.isSpecialBuilding(building.entity_name) then
         invalidateSpecialBuildingsList(city, building.entity_name)
+
+        -- TODO: this could be dropped in favor of Util.removeGlobalBuilding()
+        if global.tycoon_entity_meta_info == nil then
+            global.tycoon_entity_meta_info = {}
+        end
+        global.tycoon_entity_meta_info[unit_number] = nil
     else
         assert(building.position, "building.position is nil, DO FIX migration script!")
         -- todo: mark cell as unused again, clear paving if necessary

--- a/construction-event-handler.lua
+++ b/construction-event-handler.lua
@@ -36,6 +36,8 @@ local function on_built(event)
         global.tycoon_entity_meta_info[entity.unit_number] = {
             cityId = city.id
         }
+
+        Util.addGlobalBuilding(entity.unit_number, city.id, entity)
     end
 end
 
@@ -45,12 +47,8 @@ local function on_removed(event)
         return
     end
 
-    if global.tycoon_city_buildings == nil then
-        return
-    end
-    
     local city = nil
-    local building = global.tycoon_city_buildings[unit_number]
+    local building = Util.getGlobalBuilding(unit_number)
     if building == nil then
         return
     end
@@ -61,7 +59,7 @@ local function on_removed(event)
         -- todo: how should we handle that situation? Is the whole city gone?
         -- probably in the "destroyed" event, because the player can't mine the town hall
         -- remove from global
-        global.tycoon_city_buildings[unit_number] = nil
+        Util.removeGlobalBuilding(unit_number)
         return
     end
 
@@ -97,7 +95,7 @@ local function on_removed(event)
 
     -- todo: mark cell as unused again, clear paving if necessary
     -- remove from global
-    global.tycoon_city_buildings[unit_number] = nil
+    Util.removeGlobalBuilding(unit_number)
 end
 
 return {

--- a/migrations/0.4.6-fix-city-buildings.lua
+++ b/migrations/0.4.6-fix-city-buildings.lua
@@ -1,0 +1,125 @@
+local Constants = require("constants")
+local City = require("city")
+local Util = require("util")
+
+-- WARN: migrations are run BEFORE any init(), always need this here
+if global.tycoon_cities == nil then
+    global.tycoon_cities = {}
+end
+if global.tycoon_city_buildings == nil then
+    global.tycoon_city_buildings = {}
+end
+
+
+-- fix all special tycoon entities on every surface
+local names = {}
+for name, _ in pairs(Constants.CITY_SPECIAL_BUILDINGS) do
+    table.insert(names, name)
+end
+for _, surface in pairs(game.surfaces) do
+    local entities = surface.find_entities_filtered{
+        name=names,
+    }
+    for _, entity in ipairs(entities or {}) do
+        if entity == nil or (not entity.valid) then
+            log("ERROR: find_entities_filtered() returned invalid entity!")
+            goto continue
+        end
+
+        local position = {
+            x = math.floor(entity.position.x),
+            y = math.floor(entity.position.y),
+        }
+
+        local city = Util.findCityAtPosition(surface, position)
+        if city == nil then
+            log(string.format("ERROR: unable to find city! position: %s name: %s", serpent.line(position), entity.name))
+            game.print("no city in range, remove manually: [gps=".. position.x ..",".. position.y .."]")
+
+            -- remove bad entry if exists
+            Util.removeGlobalBuilding(entity.unit_number)
+            goto continue
+        end
+
+        local building = Util.getGlobalBuilding(entity.unit_number)
+        if building == nil then
+            log(string.format("found lost building, position: %s name: %s", serpent.line(position), entity.name))
+        end
+
+        -- force-add with proper function
+        Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+
+        ::continue::
+    end
+end
+
+-- we must ensure that all entities are still valid
+log(string.format("processing tycoon_city_buildings: %d", table_size(global.tycoon_city_buildings)))
+local new_dict = {}
+for k, building in pairs(global.tycoon_city_buildings) do
+    if building.entity == nil or (not building.entity.valid) then
+        goto continue
+    end
+
+    if building.position == nil then
+        local city = Util.findCityById(building.cityId)
+        if city == nil then
+            log(string.format("ERROR: unknown building.cityId: %s", serpent.line(building.cityId)))
+        end
+
+        building.position = {
+            x = math.floor(building.entity.position.x),
+            y = math.floor(building.entity.position.y),
+        }
+    end
+
+    new_dict[k] = building
+    ::continue::
+end
+-- rewrite whole dict
+global.tycoon_city_buildings = new_dict
+
+-- check every city
+for _, city in pairs(global.tycoon_cities) do
+    log(string.format("processing city id: %d grid: %d name: %s", city.id, #city.grid, city.name))
+
+    -- drop cache
+    for name, _ in pairs(Constants.CITY_SPECIAL_BUILDINGS) do
+        city.special_buildings.other[name] = nil
+    end
+
+    -- check city grid
+    for y = 1, #city.grid, 1 do
+        for x = 1, #city.grid, 1 do
+            local row = city.grid[y]
+            local cell = (row or {})[x]
+            if cell == nil or cell.type ~= "building" then
+                goto continue
+            end
+
+            -- if building is absent
+            local entity = cell.entity
+            if entity == nil or (not entity.valid) then
+                -- clear manually
+                city.grid[y][x] = { type = "unused" }
+                City.updatepossibleBuildingLocations(city, {x=x, y=y}, true)
+                goto continue
+            end
+
+            local building = Util.getGlobalBuilding(entity.unit_number)
+            local pos = { x = math.floor(entity.position.x), y = math.floor(entity.position.y) }
+            if building == nil then
+                log(string.format("ERROR: building is nil! unit: %s pos: %s",
+                    serpent.line(entity.unit_number), serpent.line(pos)))
+            elseif building.position.x ~= pos.x or building.position.y ~= pos.y then
+                log(string.format("ERROR: positions does not match! unit: %s bld.pos: %s ent.pos: %s name: %s",
+                    serpent.line(entity.unit_number), serpent.line(building.position), serpent.line(pos), entity.name))
+            end
+
+            -- force-add with proper function
+            Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+
+            ::continue::
+        end
+    end
+end

--- a/migrations/0.4.6-fix-city-buildings.lua
+++ b/migrations/0.4.6-fix-city-buildings.lua
@@ -104,6 +104,15 @@ for _, city in pairs(global.tycoon_cities) do
             -- if building is absent
             local entity = cell.entity
             if entity == nil or (not entity.valid) then
+                if cell.initKey == "town-hall" then
+                    -- town hall never had cell.entity assigned previously
+                    cell.entity = city.special_buildings.town_hall
+                    log("assigned town hall to cell.entity!")
+                    goto continue
+                elseif cell.initKey ~= nil then
+                    log(string.format("unknown initKey, cell: ", serpent.line(cell)))
+                end
+
                 -- clear manually
                 city.grid[y][x] = { type = "unused" }
                 City.updatepossibleBuildingLocations(city, {x=x, y=y}, true)

--- a/migrations/0.4.6-fix-city-buildings.lua
+++ b/migrations/0.4.6-fix-city-buildings.lua
@@ -48,6 +48,8 @@ for _, surface in pairs(game.surfaces) do
 
         -- force-add with proper function
         Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+        -- WARN: we must always register
+        script.register_on_entity_destroyed(entity)
 
         ::continue::
     end
@@ -71,6 +73,8 @@ for k, building in pairs(global.tycoon_city_buildings) do
             x = math.floor(building.entity.position.x),
             y = math.floor(building.entity.position.y),
         }
+        -- WARN: we must always register
+        script.register_on_entity_destroyed(building.entity)
     end
 
     new_dict[k] = building
@@ -118,6 +122,8 @@ for _, city in pairs(global.tycoon_cities) do
 
             -- force-add with proper function
             Util.addGlobalBuilding(entity.unit_number, city.id, entity)
+            -- WARN: we must always register
+            script.register_on_entity_destroyed(entity)
 
             ::continue::
         end

--- a/util.lua
+++ b/util.lua
@@ -213,6 +213,7 @@ local function findCityAtPosition(surface, position, radius, limit)
         return
     end
 
+    -- can't use getGlobalBuilding(), it is declared below
     local building = global.tycoon_city_buildings[town_halls[1].unit_number]
     if building == nil then
         log("ERROR: Found a town hall, but it has no city mapping.")

--- a/util.lua
+++ b/util.lua
@@ -274,6 +274,66 @@ local function findCityByEntityUnitNumber(unitNumber)
 end
 
 
+--- @class Building
+--- @field cityId number
+--- @field entity LuaEntity
+--- @field entity_name string
+--- @field position MapPosition | Coordinates
+--- @field isSpecial boolean | nil
+
+--- @param unit_number number
+--- @param cityId number
+--- @param entity LuaEntity | nil
+--- @return Building
+local function addGlobalBuilding(unit_number, cityId, entity)
+    if global.tycoon_city_buildings == nil then
+        global.tycoon_city_buildings = {}
+    end
+
+    if unit_number == nil then
+        return
+    end
+
+    local building = nil
+    if entity ~= nil and entity.valid then
+        building = {
+            cityId = cityId,
+            entity_name = entity.name,
+            entity = entity,
+            position = {
+                x = math.floor(entity.position.x),
+                y = math.floor(entity.position.y),
+            },
+        }
+        if isSpecialBuilding(entity.name) then
+            building.isSpecial = true
+        end
+    end
+
+    global.tycoon_city_buildings[unit_number] = building
+    return building
+end
+
+--- @param unit_number number
+local function removeGlobalBuilding(unit_number)
+    if global.tycoon_city_buildings == nil or unit_number == nil then
+        return
+    end
+
+    global.tycoon_city_buildings[unit_number] = nil
+end
+
+--- @param unit_number number
+--- @return Building
+local function getGlobalBuilding(unit_number)
+    if global.tycoon_city_buildings == nil or unit_number == nil then
+        return
+    end
+
+    return global.tycoon_city_buildings[unit_number]
+end
+
+
 --- @param start Coordinates
 --- @param map string[]
 --- @param tileName string
@@ -341,6 +401,9 @@ return {
     isHouse = isHouse,
     findCityByEntityUnitNumber = findCityByEntityUnitNumber,
 
+    addGlobalBuilding = addGlobalBuilding,
+    removeGlobalBuilding = removeGlobalBuilding,
+    getGlobalBuilding = getGlobalBuilding,
 
     printTiles = printTiles,
     aggregateSupplyBuildingResources = aggregateSupplyBuildingResources,


### PR DESCRIPTION
**READY FOR TESTING**
**DEPENDS:** ~~#307, #308~~ _don't squash, pls_

because `on_entity_destroyed` event doesn't provide `entity.position` (it's already gone!) we need to remember `.position` field in `global.tycoon_city_buildings[]` and free this cell by new `City::freeCellAtPosition()` function.
_`City::clearCell()` does different thing, sadly_ - so i'm reworking it...

### notes
i've fixed adding **all** entities from `Constants.CITY_SPECIAL_BUILDINGS` to `global.tycoon_city_buildings[]`, since code was already doing it, but not fully. this one probably should have been named as `global.tycoon_buildings`
while this could be split into _city-built_ and _player-built_ lists, it would require checking two arrays in event handlers.

ok, this was harder than i thought before. sorry for such big changes, but i couldn't find another way. diffs are horrible, looking at resulting files is easier
my tests was successful, i've tried to avoid `assert()`s so any save should still be playable, but couldn't decide in a few places (iirc). will fix asap if you find anything!

### tl;dr
- new function `City::freeCellAtPosition()`
- new functions `Util:: {add,remove,get}GlobalBuilding()`
- `global.tycoon_city_buildings[]` must now have every related `tycoon-*` entity, or `on_removed()` handler will skip it
- we always must `script.register_on_entity_destroyed(entity)` after creation
- migration script should fix possible errors in old saves
- logging might be a bit excessive, but helps testing. we can reduce it later
- **NOTE:** if any market (hw-store, etc...) is missing for a city after migration resets special buildings cache - it needs to be rebuilt or replaced closer
- _using `CITY_RADIUS` differs a little when placing vs `find_entities_*()` probably because `town-hall` vs `city.center`_

### ~~todo~~ migration
- [x] finish position processing correctly
- [x] process each city grid looking for buildings/etc, as it could be wrong
- [x] add missing entities ~~to `global.tycoon_city_buildings[]`~~ by `Util.addGlobalBuilding()`

nothing else would be needed at runtime, as new buildings will already work