### PR TITLE
fix: tags-queue typo and wrong arguments crash

### DIFF
--- a/chunk-charted-handler.lua
+++ b/chunk-charted-handler.lua
@@ -43,7 +43,7 @@ local function on_chunk_charted(event)
     -- place pending tags
     local pos_name = TagsQueue.get(event.position, event.surface_index)
     if pos_name ~= nil then
-        PrimaryIndustries.tagIndustry(table.unpack(pos_name))
+        PrimaryIndustries.tagIndustry(pos_name[1], pos_name[2], event.surface_index)
     end
 
     if global.tycoon_global_generator() < 0.25 then

--- a/tags-queue.lua
+++ b/tags-queue.lua
@@ -19,7 +19,7 @@ end
 local function set(chunk_position, surface_index, entity_name, entity_position)
     local k = key(chunk_position, surface_index)
     -- storing pos and name is a bit too much, but avoids searching for entity, which might be more expensive
-    get_queue()[k] = { pos = entity_position, entity_name, surface_index }
+    get_queue()[k] = { entity_position, entity_name, surface_index }
 end
 
 local function delete(chunk_position, surface_index)


### PR DESCRIPTION
`table.unpack()` is very hacky, so i removed it.
we also have surface_index in tag array as `[3]`, but i thought using event-supplied one is more correct here