### PR TITLE
chore: improve performance by aggregating supply building access

### DIFF
--- a/city.lua
+++ b/city.lua
@@ -1405,17 +1405,15 @@ end
 
 
 local function getBuildables(hardwareStores)
+    local supply = Util.aggregateSupplyBuildingResources(hardwareStores)
+    
     local buildables = {}
     for key, resources in pairs(Constants.CONSTRUCTION_MATERIALS) do
         local anyResourceMissing = false
         for _, resource in ipairs(resources) do
-            for _, hardwareStore in ipairs(hardwareStores) do
-                local availableCount = hardwareStore.get_item_count(resource.name)
-                resource.available = (resource.available or 0) + availableCount
-            end
-
-            if resource.available < resource.required then
+            if (supply[resource.name] or 0) < resource.required then
                 anyResourceMissing = true
+                break
             end
         end
 

--- a/consumption.lua
+++ b/consumption.lua
@@ -1,4 +1,5 @@
 local Constants = require("constants")
+local Util = require("util")
 
 --- @class Need
 --- @field provided number
@@ -253,41 +254,18 @@ end
 --- @param city City
 local function updateProvidedAmounts(city)
     local markets = listSpecialCityBuildings(city, "tycoon-market")
+    local supply = Util.aggregateSupplyBuildingResources(markets)
 
     -- BASIC NEEDS
-    if #markets >= 1 then
-        for resource, _ in pairs(city.stats.basic_needs) do
-            if resource ~= "water" then
-                local totalAvailable = 0
-                for _, market in ipairs(markets) do
-                    local availableCount = market.get_item_count(resource)
-                    totalAvailable = totalAvailable + availableCount
-                end
-                setBasicNeedsProvided(city, resource, totalAvailable)
-            end
-        end
-    else
-        for resource, _ in pairs(city.stats.basic_needs) do
-            if resource ~= "water" then
-                setBasicNeedsProvided(city, resource, 0)
-            end
+    for resource, _ in pairs(city.stats.basic_needs) do
+        if resource ~= "water" then
+            setBasicNeedsProvided(city, resource, supply[resource] or 0)
         end
     end
 
     -- ADDITIONAL NEEDS
-    if #markets >= 1 then
-        for resource, _ in pairs(city.stats.additional_needs or {}) do
-            local totalAvailable = 0
-            for _, market in ipairs(markets) do
-                local availableCount = market.get_item_count(resource)
-                totalAvailable = totalAvailable + availableCount
-            end
-            setAdditionalNeedsProvided(city, resource, totalAvailable)
-        end
-    else
-        for resource, _ in pairs(city.stats.additional_needs) do
-            setAdditionalNeedsProvided(city, resource, 0)
-        end
+    for resource, _ in pairs(city.stats.additional_needs or {}) do
+        setAdditionalNeedsProvided(city, resource, supply[resource] or 0)
     end
     
     local waterTowers = listSpecialCityBuildings(city, "tycoon-water-tower")

--- a/gui.lua
+++ b/gui.lua
@@ -101,14 +101,10 @@ local function addConstructionMaterialsGui(rootGui, constructionNeeds, city, har
     if #hardwareStores == 0 then
         tbl.add{type = "label", caption = {"", "[color=red]", {"tycoon-gui-missing", {"entity-name.tycoon-hardware-store"}}, "[/color]"}}
     else
+        local supply = Util.aggregateSupplyBuildingResources(hardwareStores)
         for _, resource in ipairs(constructionNeeds) do
 
-            local totalResourceCount = 0
-            for _, hardwareStore in ipairs(hardwareStores or {}) do
-                local availableCount = hardwareStore.get_item_count(resource)
-                totalResourceCount = totalResourceCount + availableCount
-            end
-            setConstructionMaterialsProvided(city, resource, totalResourceCount)
+            setConstructionMaterialsProvided(city, resource, supply[resource] or 0)
 
             local amounts = city.stats.construction_materials[resource] or {provided =  0}
 
@@ -410,21 +406,14 @@ end
 
 local function areConstructionNeedsMet(city, housingTier, stores) 
     local hardwareStores = stores or listSpecialCityBuildings(city, "tycoon-hardware-store")
+    local supply = Util.aggregateSupplyBuildingResources(hardwareStores)
     local needs = Constants.CONSTRUCTION_MATERIALS[housingTier]
 
     for _, need in ipairs(needs) do
-        -- name/required
-        local totalAvailable = 0
-        for _, store in ipairs(hardwareStores) do
-            local availableCount = store.get_item_count(need.name)
-            totalAvailable = totalAvailable + availableCount
-        end
-
-        if need.required > totalAvailable then
+        if need.required > (supply[need.name] or 0) then
             return false
         end
     end
-
     return true
 end
 

--- a/util.lua
+++ b/util.lua
@@ -209,6 +209,19 @@ local function findCityByEntityUnitNumber(unitNumber)
     return cityName or "Unknown"
 end
 
+local function aggregateSupplyBuildingResources(supplyBuildings)
+    local resources = {}
+
+    for _, entity in ipairs(supplyBuildings) do
+        local contents = entity.get_inventory(defines.inventory.chest).get_contents()
+        for item, count in pairs(contents) do
+            resources[item] = (resources[item] or 0) + count
+        end
+    end
+
+    return resources
+end
+
 return {
     countPendingLowerTierHouses = countPendingLowerTierHouses,
     hasReachedLowerTierThreshold = hasReachedLowerTierThreshold,
@@ -237,4 +250,6 @@ return {
     isSupplyBuilding = isSupplyBuilding,
     isHouse = isHouse,
     findCityByEntityUnitNumber = findCityByEntityUnitNumber,
+
+    aggregateSupplyBuildingResources = aggregateSupplyBuildingResources,
 }


### PR DESCRIPTION
This PR improves the performance of the Tycoon mod by 10.7%. I changed repeat lookups of items in supply buildings into a util function that aggregates the resources of all items in a list of supply buildings.

Ran the same save for 10 minutes. On this branch the profiler said that tycoon used 412ms, while on main it was 461ms.