### PR TITLE
chore: reduce arguments and couple of new functions

### DIFF
--- a/city.lua
+++ b/city.lua
@@ -94,20 +94,19 @@ local function getCachedDistance(coordinates, offsetY, offsetX, cityCenter)
     end
 end
 
---- @param y number
---- @param x number
+--- @param origin Coordinates
 --- @param size number
 --- @param allowDiagonal boolean
 --- @return Coordinates[] coordinates
-local function getSurroundingCoordinates(y, x, size, allowDiagonal)
+local function getSurroundingCoordinates(origin, size, allowDiagonal)
    local c = {}
    for i = -1 * size, size, 1 do
         for j = -1 * size, size, 1 do
             if (allowDiagonal or (math.abs(i) ~= math.abs(j))) then
                 if not(i == 0 and j == 0) then
                     table.insert(c, {
-                        y = i + y,
-                        x = j + x
+                        x = j + origin.x,
+                        y = i + origin.y
                     })
                 end
             end
@@ -116,8 +115,7 @@ local function getSurroundingCoordinates(y, x, size, allowDiagonal)
    return c
 end
 
---- @param y number
---- @param x number
+--- @param origin Coordinates
 --- @param size number
 --- @param city City
 --- @return any
@@ -288,7 +286,7 @@ end
 --- @param city City
 --- @param coordinates Coordinates
 local function hasSurroundingRoad(city, coordinates)
-    local surroundsOfUnused = getSurroundingCoordinates(coordinates.y, coordinates.x, 1, false)
+    local surroundsOfUnused = getSurroundingCoordinates(coordinates, 1, false)
     for _, s in ipairs(surroundsOfUnused) do
         local surroundingCell = GridUtil.safeGridAccess(city, s)
         if surroundingCell ~= nil and surroundingCell.type == "road" then
@@ -716,7 +714,7 @@ local function addBuildingLocations(city, recentCoordinates)
     end
 
     if recentCoordinates ~= nil then
-        local surrounds = getSurroundingCoordinates(recentCoordinates.y, recentCoordinates.x, 1, false)
+        local surrounds = getSurroundingCoordinates(recentCoordinates, 1, false)
         for _, value in ipairs(surrounds) do
             if value.x <= 1 or value.y <= 1 or value.x >= #city.grid or value.y >= #city.grid then
                 -- Skip locations that are at the edge of the grid or beyond
@@ -727,7 +725,7 @@ local function addBuildingLocations(city, recentCoordinates)
                 if isUnused then
 
                     -- Then check if there are any open roadEnds surrounding this unused field
-                    local surroundsOfUnused = getSurroundingCoordinates(value.y, value.x, 1, false)
+                    local surroundsOfUnused = getSurroundingCoordinates(value, 1, false)
                     local hasSurroundingRoadEnd = false
                     for _, s in ipairs(surroundsOfUnused) do
                         if Util.indexOf(recentCoordinates, s) ~= nil then
@@ -784,7 +782,7 @@ end
 --- @param coordinates Coordinates
 --- @return boolean
 local function isConnectedToRoad(city, coordinates)
-    local surrounds = getSurroundingCoordinates(coordinates.y, coordinates.x, 1, false)
+    local surrounds = getSurroundingCoordinates(coordinates, 1, false)
     for _, s in ipairs(surrounds) do
         local c = GridUtil.safeGridAccess(city, s)
         if c ~= nil and c.type == "road" then
@@ -1228,11 +1226,11 @@ local function completeConstruction(city, buildingTypes)
         end
         table.insert(city.houseLocations, coordinates)
 
-        local sideNeighboursOfCompletedHouse = getSurroundingCoordinates(coordinates.y, coordinates.x, 1, false)
+        local sideNeighboursOfCompletedHouse = getSurroundingCoordinates(coordinates, 1, false)
         for _, n in ipairs(sideNeighboursOfCompletedHouse) do
             local neighbourCell = GridUtil.safeGridAccess(city, n)
             if neighbourCell ~= nil and neighbourCell.type == "unused" then
-                local surroundsOfUnused = getSurroundingCoordinates(n.y, n.x, 1, false)
+                local surroundsOfUnused = getSurroundingCoordinates(n, 1, false)
                 -- Test if this cell is surrounded by houses, if yes then place a garden
                 -- Because we use getSurroundingCoordinates with allowDiagonal=false above, we only need to count 4 houses or roads
                 local surroundCount = 0

--- a/city.lua
+++ b/city.lua
@@ -97,9 +97,13 @@ end
 --- @param origin Coordinates
 --- @param size number
 --- @param allowDiagonal boolean
+--- @param allowCenter boolean
 --- @return Coordinates[] coordinates
-local function getSurroundingCoordinates(origin, size, allowDiagonal)
+local function getSurroundingCoordinates(origin, size, allowDiagonal, allowCenter)
    local c = {}
+   if allowCenter then
+       table.insert(c, origin)
+   end
    for i = -1 * size, size, 1 do
         for j = -1 * size, size, 1 do
             if (allowDiagonal or (math.abs(i) ~= math.abs(j))) then

--- a/city.lua
+++ b/city.lua
@@ -1460,8 +1460,6 @@ local function construct_gardens()
     end
 end
 
-local housing_tiers = {"simple", "residential", "highrise"}
-
 local lower_tiers = {
     highrise = "residential",
     residential = "simple"
@@ -1524,7 +1522,8 @@ local function start_house_construction()
 
             local buildables = getBuildables(hardware_stores)
             -- If there are no hardware stores, then no construction resources are available.
-            for _, tier in ipairs(housing_tiers) do
+            -- use CITIZEN_COUNTS as housing tiers list
+            for tier, _ in pairs(Constants.CITIZEN_COUNTS) do
                 if has_time_elapsed_for_construction(city, tier)
                     and buildables[tier] ~= nil then
                         

--- a/city.lua
+++ b/city.lua
@@ -709,7 +709,8 @@ end
 
 --- @param city City
 --- @param recentCoordinates Coordinates | nil
-local function addBuildingLocations(city, recentCoordinates)
+--- @param allowCenter boolean | nil
+local function addBuildingLocations(city, recentCoordinates, allowCenter)
     if city.buildingLocationQueue == nil then
         city.buildingLocationQueue = Queue.new()
     end
@@ -718,7 +719,7 @@ local function addBuildingLocations(city, recentCoordinates)
     end
 
     if recentCoordinates ~= nil then
-        local surrounds = getSurroundingCoordinates(recentCoordinates, 1, false)
+        local surrounds = getSurroundingCoordinates(recentCoordinates, 1, false, allowCenter)
         for _, value in ipairs(surrounds) do
             if value.x <= 1 or value.y <= 1 or value.x >= #city.grid or value.y >= #city.grid then
                 -- Skip locations that are at the edge of the grid or beyond

--- a/debug.lua
+++ b/debug.lua
@@ -29,12 +29,12 @@ local function logGrid(grid, logFn)
         end
         local s = #grid
         for y = 1, s, 1 do
-            local printRow = y .. ": "
+            local printRow = string.format("%3d: ", y)
             local row = grid[y]
             for x = 1, s, 1 do
                 local cell = row[x]
                 if cell.type == "unused" then
-                    printRow = printRow .. " .  "
+                    printRow = printRow .. ". "
                 elseif cell.type == "building" then
                     printRow = printRow .. "H "
                 elseif cell.type == "road" then

--- a/grid-util.lua
+++ b/grid-util.lua
@@ -4,6 +4,7 @@ local function getGridSize(grid)
     return #grid
 end
 
+--- @param city City
 --- @param coordinates Coordinates
 --- @param sendWarningForMethod string | nil
 --- @return any | nil cell

--- a/grid-util.lua
+++ b/grid-util.lua
@@ -26,6 +26,19 @@ local function safeGridAccess(city, coordinates, sendWarningForMethod)
 end
 
 --- @param city City
+--- @param coordinates Coordinates
+--- @param value Cell
+--- @return any | nil cell
+local function safeGridSet(city, coordinates, value)
+    local row = city.grid[coordinates.y]
+    if row ~= nil then
+        -- make sure we don't set local
+        city.grid[coordinates.y][coordinates.x] = value
+        return row[coordinates.x]
+    end
+end
+
+--- @param city City
 local function getOffsetX(city)
     -- -3 is because the center starts at the top left of the initial 3x3 grid. so at the beginning there must be no additional offset.
     -- but then it should grow by one for each grid expansion (each expansion is 2 rows and columns, so we divide it by 2)
@@ -55,10 +68,18 @@ local function translateCityGridToTileCoordinates(city, coordinates)
     }
 end
 
+local function translateToGrid(city, position)
+    local x = 1 + math.floor(math.floor(position.x - getOffsetX(city)) / Constants.CELL_SIZE)
+    local y = 1 + math.floor(math.floor(position.y - getOffsetY(city)) / Constants.CELL_SIZE)
+    return {x = x, y = y}
+end
+
 return {
     getGridSize = getGridSize,
     getOffsetX = getOffsetX,
     getOffsetY = getOffsetY,
     safeGridAccess = safeGridAccess,
+    safeGridSet = safeGridSet,
     translateCityGridToTileCoordinates = translateCityGridToTileCoordinates,
+    translateToGrid = translateToGrid,
 }


### PR DESCRIPTION
picked these short and clean commits from destruction handling, so anything can be reverted easily

i know that `{y = 0, x = 0}` should be the same as `{x=, y=}`, but Factorio says it tries to keep order of insertion (don't remember for what exactly, though).
so it seems wrong if something would try to access it as `coords[1], coords[2]` which is allowed for `MapPosition` type

i have 2 more commits, adding `allowCenter` in `addBuildingLocations()`, ~~but i couldn't test if it works, yet~~
**edit:** yes, these are needed for rebuilding after destroy event