### PR TITLE
feat: drop dirt roads, and use landfill roads again; fix false downgrades

### DIFF
--- a/city-planner.lua
+++ b/city-planner.lua
@@ -210,8 +210,10 @@ local function initializeCity(city)
                 local startCoordinates = GridUtil.translateCityGridToTileCoordinates(city, { x = x, y = y })
                 clearCell(startCoordinates.y, startCoordinates.x)
                 if map ~= nil then
-                    -- Landfill is what we start with. It's later upgraded to higher tier roads as the citizens improve.
-                    Util.printTiles(startCoordinates, map, Constants.GROUND_TILE_TYPES.simple, city.surface_index)
+                    -- If we were to start with landfill around the town hall, we'd get unpretty edges when new dirt roads are built.
+                    -- It also looks odd when residential buildings upgrade to stone around them, but their range doesn't reach the town hall.
+                    -- That's why it looks nicer to just start with stone tiles around the town hall.
+                    Util.printTiles(startCoordinates, map, Constants.GROUND_TILE_TYPES.residential, city.surface_index)
                 end
                 if cell.initKey == "town-hall" then
                     local thPosition = {

--- a/city.lua
+++ b/city.lua
@@ -600,90 +600,45 @@ local function pickRoadExpansion(city, roadEnd)
 end
 
 --- @param direction Direction
---- @param wide boolean
 --- @return string[] map
 local function getMap(direction, wide)
     local result = nil
     if direction == "north" then
-        if wide then
-            result = {
-                "011110",
-                "011110",
-                "011110",
-                "011110",
-                "000000",
-                "000000",
-            }
-        else
-            result = {
-                "001100",
-                "001100",
-                "001100",
-                "001100",
-                "000000",
-                "000000",
-            }
-        end
+        result = {
+            "001100",
+            "001100",
+            "001100",
+            "001100",
+            "000000",
+            "000000",
+        }
     elseif direction == "south" then
-        if wide then
-            result = {
-                "000000",
-                "000000",
-                "011110",
-                "011110",
-                "011110",
-                "011110",
-            }
-        else
-            result = {
-                "000000",
-                "000000",
-                "001100",
-                "001100",
-                "001100",
-                "001100",
-            }
-        end
+        result = {
+            "000000",
+            "000000",
+            "001100",
+            "001100",
+            "001100",
+            "001100",
+        }
     elseif direction == "west" then
-        if wide then
-            result = {
-                "000000",
-                "111100",
-                "111100",
-                "111100",
-                "111100",
-                "000000",
-            }
-        else
-            result = {
-                "000000",
-                "000000",
-                "111100",
-                "111100",
-                "000000",
-                "000000",
-            }
-        end
+        result = {
+            "000000",
+            "000000",
+            "111100",
+            "111100",
+            "000000",
+            "000000",
+        }
     elseif direction == "east" then
-        if wide then
-            result = {
-                "000000",
-                "001111",
-                "001111",
-                "001111",
-                "001111",
-                "000000",
-            }
-        else
-            result = {
-                "000000",
-                "000000",
-                "001111",
-                "001111",
-                "000000",
-                "000000",
-            }
-        end
+        result = {
+            "000000",
+            "000000",
+            "001111",
+            "001111",
+            "000000",
+            "000000",
+        }
     end
     assert(result ~= nil, "Invalid direction for getMap")
     return result
@@ -943,6 +898,7 @@ local function clearAreaAndPrintTiles(city, coordinates, map, tileType)
         y = coordinates.y,
     })
     Util.printTiles(currentCellStartCoordinates, map, tileType, city.surface_index)
+    -- {Constants.GROUND_TILE_TYPES.residential, Constants.GROUND_TILE_TYPES.highrise}
 
     local currentArea = {
         {currentCellStartCoordinates.x, currentCellStartCoordinates.y},
@@ -1028,8 +984,7 @@ local function growAtRandomRoadEnd(city)
         -- For each direction, fill the current cell with the direction and the neighbour with the inverse direction
         for _, direction in ipairs(pickedExpansionDirections) do
 
-            -- Landfill is what we start with. It's later upgraded to higher tier roads as the citizens improve.
-            clearAreaAndPrintTiles(city, roadEnd.coordinates, getMap(direction, true), Constants.GROUND_TILE_TYPES.road)
+            clearAreaAndPrintTiles(city, roadEnd.coordinates, getMap(direction), Constants.GROUND_TILE_TYPES.road)
 
             local currentCell = GridUtil.safeGridAccess(city, roadEnd.coordinates, "processPickedExpansionDirectionCurrent")
             if currentCell == nil then
@@ -1055,7 +1010,7 @@ local function growAtRandomRoadEnd(city)
             end
 
             local neighbourSocket = invertDirection(direction)
-            clearAreaAndPrintTiles(city, neighbourPosition, getMap(neighbourSocket, true), Constants.GROUND_TILE_TYPES.road)
+            clearAreaAndPrintTiles(city, neighbourPosition, getMap(direction), Constants.GROUND_TILE_TYPES.road)
 
             local neighbourCell = GridUtil.safeGridAccess(city, neighbourPosition, "processPickedExpansionDirectionNeighbour")
             if neighbourCell == nil then

--- a/city.lua
+++ b/city.lua
@@ -897,8 +897,7 @@ local function clearAreaAndPrintTiles(city, coordinates, map, tileType)
         x = coordinates.x,
         y = coordinates.y,
     })
-    Util.printTiles(currentCellStartCoordinates, map, tileType, city.surface_index)
-    -- {Constants.GROUND_TILE_TYPES.residential, Constants.GROUND_TILE_TYPES.highrise}
+    Util.printTiles(currentCellStartCoordinates, map, tileType, city.surface_index, {Constants.GROUND_TILE_TYPES.residential, Constants.GROUND_TILE_TYPES.highrise})
 
     local currentArea = {
         {currentCellStartCoordinates.x, currentCellStartCoordinates.y},
@@ -1010,7 +1009,7 @@ local function growAtRandomRoadEnd(city)
             end
 
             local neighbourSocket = invertDirection(direction)
-            clearAreaAndPrintTiles(city, neighbourPosition, getMap(direction), Constants.GROUND_TILE_TYPES.road)
+            clearAreaAndPrintTiles(city, neighbourPosition, getMap(neighbourSocket), Constants.GROUND_TILE_TYPES.road)
 
             local neighbourCell = GridUtil.safeGridAccess(city, neighbourPosition, "processPickedExpansionDirectionNeighbour")
             if neighbourCell == nil then

--- a/constants.lua
+++ b/constants.lua
@@ -90,8 +90,8 @@ local CONSTANTS = {
     },
 
     GROUND_TILE_TYPES = {
-        road = "dry-dirt",
-        simple = "landfill",
+        road = "stone-path",
+        simple = "stone-path",
         residential = "stone-path",
         highrise = "concrete",
     },

--- a/constants.lua
+++ b/constants.lua
@@ -90,8 +90,8 @@ local CONSTANTS = {
     },
 
     GROUND_TILE_TYPES = {
-        road = "stone-path",
-        simple = "stone-path",
+        road = "landfill",
+        simple = "landfill",
         residential = "stone-path",
         highrise = "concrete",
     },

--- a/util.lua
+++ b/util.lua
@@ -338,14 +338,25 @@ end
 --- @param start Coordinates
 --- @param map string[]
 --- @param tileName string
+--- @param dont_override_tiles string[] | nil
 --- @param surface_index number
-local function printTiles(start, map, tileName, surface_index)
+local function printTiles(start, map, tileName, surface_index, dont_override_tiles)
+    if dont_override_tiles == nil then
+        dont_override_tiles = {}
+    end
     local x, y = start.x, start.y
     for _, value in ipairs(map) do
         for i = 1, #value do
             local char = string.sub(value, i, i)
             if char == "1" then
-                game.surfaces[surface_index or Constants.STARTING_SURFACE_ID].set_tiles({ { name = tileName, position = { x, y } } })
+                local can_print = true
+                if #dont_override_tiles > 0 then
+                    local tile = game.surfaces[surface_index].get_tile(x, y)
+                    can_print = indexOf(dont_override_tiles, tile.name) == nil
+                end
+                if can_print then
+                    game.surfaces[surface_index or Constants.STARTING_SURFACE_ID].set_tiles({ { name = tileName, position = { x, y } } })
+                end
             end
             x = x + 1
         end


### PR DESCRIPTION
I wasn't happy with the way that dirt roads turned out. They weren't visible on the similar looking surfaces, needed different tile maps, and turned out to be tricky to handle when checking the ground tiles ahead of time.

Since I'm not able to get results that I'm happy with, I decided to revert back to landfill.

Feel free to take another attempt at it, but it may become a bit tricky.