### PR TITLE
fix: used-bottles-store crashing with a bad argument to generator

### DIFF
--- a/used-bottles-store.lua
+++ b/used-bottles-store.lua
@@ -51,6 +51,9 @@ local function return_used_bottles(city)
     for _, entry in pairs(stations_with_space) do
         if entry.available_slots > 1 then
             local share_per_station = math.ceil(current_count / #stations)
+            if share_per_station == 0 then
+                break
+            end
             local target_quantity = city.generator(share_per_station)
             local quantity = math.min(share_per_station, target_quantity)
             local used_bottles_stack_size = 50 -- todo: can we load this from the prototype?


### PR DESCRIPTION
used-bottles-store.lua crashes when the city tries to return zero bottles

I added a check that simply skips calling `city.generator(0)` because it would generate a number between `[0, 1]` which crashes

[LuaRandomGenerator](https://lua-api.factorio.com/latest/classes/LuaRandomGenerator.html)

![image](https://github.com/user-attachments/assets/db8c04a7-f716-4a33-8167-e02149f4cd43)